### PR TITLE
at-spi2-core 2.36.0: x11_gui_rebuilds

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,6 @@ if [[ $target_platform == osx-arm64 ]]; then
 fi
 
 meson setup builddir \
-    -D enable_docs=false \
     ${DX11} \
     --prefix=$PREFIX \
     --libdir=$PREFIX/lib  \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,15 +4,14 @@
 {% set name = "at-spi2-core" %}
 {% set version = "2.36.0" %}
 {% set version_majmin = '.'.join(version.split('.', 2)[:2]) %}
-{% set sha256 = "88da57de0a7e3c60bc341a974a80fdba091612db3547c410d6deab039ca5c05a" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: http://https.gnome.org/pub/gnome/sources/{{ name }}/{{ version_majmin }}/{{ name }}-{{ version }}.tar.xz
-  sha256: {{ sha256 }}
+  url: https://download.gnome.org/sources/{{ name }}/{{ version_majmin }}/{{ name }}-{{ version }}.tar.xz
+  sha256: 88da57de0a7e3c60bc341a974a80fdba091612db3547c410d6deab039ca5c05a
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,10 @@ requirements:
     - pkg-config
     - pthread-stubs  # [linux]
     - {{ compiler('c') }}
+    # gobject-introspection 1.* requires setuptools at runtime, but
+    # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
+    # https://github.com/pypa/setuptools/pull/3505
+    - setuptools <65
   host:
     - dbus
     - gettext

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,13 +32,15 @@ requirements:
     - pkg-config
     - pthread-stubs  # [linux]
     - {{ compiler('c') }}
+    # object-introspection must be in the build section, not host, otherwise the wrong Python version 
+    # will be found by the build system and the build can randomly fail.
+    - gobject-introspection
     # gobject-introspection 1.* requires setuptools at runtime, but
-    # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
+    # setuptools >= 74.0.0 is lacking the msvccompiler module in distutils.
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <74
-    - gobject-introspection
+    # Using fixed version of Python 3.9 to avoid issues with limited Python versions of setuptools <74.0.0 available.
     - python 3.9
-    - gsl
   host:
     - dbus
     - gettext
@@ -53,7 +55,6 @@ requirements:
     - dbus
     - gettext
     - glib
-    - gobject-introspection
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,13 +36,11 @@ requirements:
     # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <74
-    - python 3.12
-    - gobject-introspection 1.*  # [not win]
   host:
     - dbus
     - gettext
     - glib
-    - gobject-introspection
+    - gobject-introspection 1.*
     - python
     - xorg-libx11  # [linux]
     - xorg-libxi  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,9 @@ requirements:
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <74
     - gobject-introspection
-    - python 3.9
+    - gsl
   host:
+    - gsl
     - dbus
     - gettext
     - glib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <74
     - gobject-introspection
+    - python 3.9
   host:
     - dbus
     - gettext

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,14 @@ requirements:
     # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <65
+    - python 3.12
+    - gobject-introspection 1.*  # [not win]
   host:
     - dbus
     - gettext
     - glib
     - gobject-introspection
+    - python
     - xorg-libx11  # [linux]
     - xorg-libxi  # [linux]
     - xorg-libxfixes  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <74
+    - gobject-introspection
   host:
     - dbus
     - gettext

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,8 @@ requirements:
     # gobject-introspection 1.* requires setuptools at runtime, but
     # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
     # https://github.com/pypa/setuptools/pull/3505
-    - setuptools <65
-    - python 3.11
+    - setuptools <74
+    - python 3.12
     - gobject-introspection 1.*  # [not win]
   host:
     - dbus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <74
     - gobject-introspection
+    - python 3.9
     - gsl
   host:
     - dbus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pkg-config
     - pthread-stubs  # [linux]
     - {{ compiler('c') }}
-    # object-introspection must be in the build section, not host, otherwise the wrong Python version 
+    # gobject-introspection must be in the build section, not host, otherwise the wrong Python version 
     # will be found by the build system and the build can randomly fail.
     - gobject-introspection
     # gobject-introspection 1.* requires setuptools at runtime, but

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,10 @@
-# Prior to conda-forge, Copyright 2014-2018 Peter Williams and collaborators.
-# This file is licensed under a 3-clause BSD license; see LICENSE.txt.
-
 {% set name = "at-spi2-core" %}
 {% set version = "2.36.0" %}
-{% set version_majmin = '.'.join(version.split('.', 2)[:2]) %}
+{% set version_majmin = "'.'.join(version.split('.', 2)[:2])" %}
 {% set sha256 = "88da57de0a7e3c60bc341a974a80fdba091612db3547c410d6deab039ca5c05a" %}
 
+# Prior to conda-forge, Copyright 2014-2018 Peter Williams and collaborators.
+# This file is licensed under a 3-clause BSD license; see LICENSE.txt.
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -15,15 +14,16 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 3
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('at-spi2-core', max_pin='x.x') }}
-  missing_dso_whitelist:   # [linux]
-    - '*/libX11.so*'  # [linux]
+  missing_dso_whitelist:  # [linux]
+    - "*/libX11.so*"  # [linux]
     - $RPATH/libc.so.6  # [linux]
   ignore_run_exports:
     - gettext
+
 requirements:
   build:
     - meson
@@ -32,16 +32,16 @@ requirements:
     - pkg-config
     - pthread-stubs  # [linux]
     - {{ compiler('c') }}
-    - {{ cdt('libx11-devel') }}  # [linux]
-    - {{ cdt('libxi-devel') }}  # [linux]
-    - {{ cdt('libxfixes-devel') }}  # [linux]
-    - {{ cdt('libxtst-devel') }}  # [linux and not ppc64le]
-    - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
   host:
     - dbus
     - gettext
     - glib
     - gobject-introspection
+    - xorg-libx11
+    - xorg-libxi
+    - xorg-libxfixes
+    - xorg-libxtst
+    - xorg-xproto
   run:
     - dbus
     - gettext

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,11 @@
+# Prior to conda-forge, Copyright 2014-2018 Peter Williams and collaborators.
+# This file is licensed under a 3-clause BSD license; see LICENSE.txt.
+
 {% set name = "at-spi2-core" %}
 {% set version = "2.36.0" %}
 {% set version_majmin = '.'.join(version.split('.', 2)[:2]) %}
 {% set sha256 = "88da57de0a7e3c60bc341a974a80fdba091612db3547c410d6deab039ca5c05a" %}
 
-# Prior to conda-forge, Copyright 2014-2018 Peter Williams and collaborators.
-# This file is licensed under a 3-clause BSD license; see LICENSE.txt.
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -45,7 +46,6 @@ requirements:
     - dbus
     - gettext
     - glib
-    - python
     - xorg-libx11  # [linux]
     - xorg-libxi  # [linux]
     - xorg-libxfixes  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "at-spi2-core" %}
 {% set version = "2.36.0" %}
-{% set version_majmin = "'.'.join(version.split('.', 2)[:2])" %}
+{% set version_majmin = '.'.join(version.split('.', 2)[:2]) %}
 {% set sha256 = "88da57de0a7e3c60bc341a974a80fdba091612db3547c410d6deab039ca5c05a" %}
 
 # Prior to conda-forge, Copyright 2014-2018 Peter Williams and collaborators.
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 2
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('at-spi2-core', max_pin='x.x') }}
@@ -37,11 +37,11 @@ requirements:
     - gettext
     - glib
     - gobject-introspection
-    - xorg-libx11
-    - xorg-libxi
-    - xorg-libxfixes
-    - xorg-libxtst
-    - xorg-xproto
+    - xorg-libx11  # [linux]
+    - xorg-libxi  # [linux]
+    - xorg-libxfixes  # [linux]
+    - xorg-libxtst  # [linux]
+    - xorg-xorgproto  # [linux]
   run:
     - dbus
     - gettext

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,10 +46,7 @@ requirements:
     - gettext
     - glib
     - xorg-libx11  # [linux]
-    - xorg-libxi  # [linux]
-    - xorg-libxfixes  # [linux]
     - xorg-libxtst  # [linux]
-    - xorg-xorgproto  # [linux]
   run:
     - dbus
     - gettext

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,11 +39,9 @@ requirements:
     - gobject-introspection
     - gsl
   host:
-    - gsl
     - dbus
     - gettext
     - glib
-    - gobject-introspection 1.*
     - python
     - xorg-libx11  # [linux]
     - xorg-libxi  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <65
-    - python 3.12
+    - python 3.11
     - gobject-introspection 1.*  # [not win]
   host:
     - dbus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://ftp.gnome.org/pub/gnome/sources/{{ name }}/{{ version_majmin }}/{{ name }}-{{ version }}.tar.xz
+  url: http://https.gnome.org/pub/gnome/sources/{{ name }}/{{ version_majmin }}/{{ name }}-{{ version }}.tar.xz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7759](https://anaconda.atlassian.net/browse/PKG-7759)
- [Upstream repository](https://gitlab.gnome.org/GNOME/at-spi2-core)

### Explanation of changes:

- Bump the build number from 1 to 2
- Remove the obsolete `-D enable_docs=false` option from meson build
- Move `gobject-introspection` from `host` to `build` section to ensure a correct Python version is used
- Remove CDTs from `build` section, relying on conda packages in `host` (xorg-libx11, xorg-libxi, etc.)
- Update `setuptools` pinning comment to reference version <74.0.0
- Fix Python version to `3.9` to avoid issues with limited `setuptools <74.0.0` availability (py312 isn't available)
- Add documentation comments explaining the build configuration

Notes:

- This is part of the automated migration/rebuild for the x11_gui_rebuilds group, which is rebuilding the X11 GUI stack
- at-spi2-core is in stage 0 of the x11_gui_rebuilds migration, which is foundational for later packages

[PKG-7759]: https://anaconda.atlassian.net/browse/PKG-7759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ