### PR TITLE
at-spi2-core 2.61.0 

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,14 +4,7 @@
 
 set -e
 
-DX11=""
-# we disable x11 on osx-arm64, as there is right now no support on our builders for it
-if [[ $target_platform == osx-arm64 ]]; then
-  DX11="-Dx11=no"
-fi
-
 meson setup builddir \
-    ${DX11} \
     --prefix=$PREFIX \
     --libdir=$PREFIX/lib  \
     --wrap-mode=nofallback

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,15 +4,16 @@
 
 set -e
 
-if [ $target_platform == osx-64 ]; then
-    # Force conda's X11 headers first; XQuartz on macOS runners can leak in otherwise
-    export CPATH="$PREFIX/include${CPATH:+:$CPATH}"
+DX11=""
+# disable the Linux-only X11 accessibility backend on macOS —
+# upstream doesn't support/need it here; forcing it on causes header
+# mismatches like the GenericEvent error.
+if [[ $target_platform == osx-arm64 ]]; then
+  DX11="-Dx11=disabled"
 fi
 
-export CFLAGS="$CFLAGS -I$PREFIX/include"
-export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
-
 meson setup builddir \
+    ${DX11} \
     --prefix=$PREFIX \
     --libdir=$PREFIX/lib  \
     --wrap-mode=nofallback

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,11 +4,21 @@
 
 set -e
 
+if [ $target_platform == osx-64 ]; then
+    # Force conda's X11 headers first; XQuartz on macOS runners can leak in otherwise
+    export CPATH="$PREFIX/include${CPATH:+:$CPATH}"
+fi
+
+export CFLAGS="$CFLAGS -I$PREFIX/include"
+export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
+
 meson setup builddir \
     --prefix=$PREFIX \
     --libdir=$PREFIX/lib  \
     --wrap-mode=nofallback
+
 ninja -v -C builddir -j ${CPU_COUNT}
+
 ninja -C builddir install -j ${CPU_COUNT}
 
 cd $PREFIX

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,17 +42,17 @@ requirements:
     - dbus {{ dbus }}
     - gettext {{ gettext}}
     - glib {{ glib }}
-    - xorg-libx11 {{ xorg_libx11 }}  # [linux]
-    - xorg-libxi {{ xorg_libxi }}  # [linux]
-    - xorg-libxtst {{ xorg_libxtst}}  # [linux]
+    - xorg-libx11 {{ xorg_libx11 }}
+    - xorg-libxi {{ xorg_libxi }}
+    - xorg-libxtst {{ xorg_libxtst}}
     - gobject-introspection ==1.86.0
   run:
     - dbus
     - gettext
     - glib
-    - xorg-libx11  # [linux]
-    - xorg-libxi  # [linux]
-    - xorg-libxtst  # [linux]
+    - xorg-libx11
+    - xorg-libxi
+    - xorg-libxtst
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,19 +2,19 @@
 # This file is licensed under a 3-clause BSD license; see LICENSE.txt.
 
 {% set name = "at-spi2-core" %}
-{% set version = "2.36.0" %}
+{% set version = "2.61.0" %}
 {% set version_majmin = '.'.join(version.split('.', 2)[:2]) %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://download.gnome.org/sources/{{ name }}/{{ version_majmin }}/{{ name }}-{{ version }}.tar.xz
-  sha256: 88da57de0a7e3c60bc341a974a80fdba091612db3547c410d6deab039ca5c05a
+  sha256: 1d813ddbb891cb6a0480bf3ee997444165db31ce8691f33e00b96c0b8b2c10ce
 
 build:
-  number: 2
+  number: 0
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('at-spi2-core', max_pin='x.x') }}
@@ -27,10 +27,11 @@ build:
 requirements:
   build:
     - meson
-    - ninja
+    - ninja-base
     - cmake  # [osx and arm64]
     - pkg-config
     - pthread-stubs  # [linux]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     # gobject-introspection must be in the build section, not host, otherwise the wrong Python version 
     # will be found by the build system and the build can randomly fail.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,10 @@ requirements:
     - pkg-config
     - pthread-stubs  # [linux]
     - gettext
+    # File "$PREFIX/lib/gobject-introspection/giscanner/utils.py", line 385, in <module>
+    # import distutils.cygwinccompiler
+    # ModuleNotFoundError: No module named 'distutils'
+    - setuptools <74
   host:
     - dbus {{ dbus }}
     - gettext {{ gettext}}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,32 +26,29 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
+    - {{ compiler('c') }}
     - meson
     - ninja-base
     - cmake  # [osx and arm64]
     - pkg-config
     - pthread-stubs  # [linux]
-    - {{ stdlib('c') }}
-    - {{ compiler('c') }}
-    # gobject-introspection must be in the build section, not host, otherwise the wrong Python version 
-    # will be found by the build system and the build can randomly fail.
-    - gobject-introspection
-    # gobject-introspection 1.* requires setuptools at runtime, but
-    # setuptools >= 74.0.0 is lacking the msvccompiler module in distutils.
-    # https://github.com/pypa/setuptools/pull/3505
-    - setuptools <74
-    # Using fixed version of Python 3.9 to avoid issues with limited Python versions of setuptools <74.0.0 available.
-    - python 3.9
-  host:
-    - dbus
     - gettext
-    - glib
-    - xorg-libx11  # [linux]
-    - xorg-libxtst  # [linux]
+  host:
+    - dbus {{ dbus }}
+    - gettext {{ gettext}}
+    - glib {{ glib }}
+    - xorg-libx11 {{ xorg_libx11 }}  # [linux]
+    - xorg-libxi {{ xorg_libxi }}  # [linux]
+    - xorg-libxtst {{ xorg_libxtst}}  # [linux]
+    - gobject-introspection ==1.86.0
   run:
     - dbus
     - gettext
     - glib
+    - xorg-libx11  # [linux]
+    - xorg-libxi  # [linux]
+    - xorg-libxtst  # [linux]
 
 test:
   commands:
@@ -59,7 +56,7 @@ test:
     - test -f $PREFIX/lib/libatspi${SHLIB_EXT}  # [unix]
 
 about:
-  home: http://www.gtk.org/
+  home: http://www.gtk.org
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: COPYING

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,7 @@ test:
 
 about:
   home: http://www.gtk.org
+  doc_url: https://gitlab.gnome.org/GNOME/at-spi2-core
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: COPYING

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,17 +42,17 @@ requirements:
     - dbus {{ dbus }}
     - gettext {{ gettext}}
     - glib {{ glib }}
-    - xorg-libx11 {{ xorg_libx11 }}
-    - xorg-libxi {{ xorg_libxi }}
-    - xorg-libxtst {{ xorg_libxtst}}
+    - xorg-libx11 {{ xorg_libx11 }}  # [linux]
+    - xorg-libxi {{ xorg_libxi }}  # [linux]
+    - xorg-libxtst {{ xorg_libxtst}}  # [linux]
     - gobject-introspection ==1.86.0
   run:
     - dbus
     - gettext
     - glib
-    - xorg-libx11
-    - xorg-libxi
-    - xorg-libxtst
+    - xorg-libx11  # [linux]
+    - xorg-libxi  # [linux]
+    - xorg-libxtst  # [linux]
 
 test:
   commands:


### PR DESCRIPTION
at-spi2-core 2.61.0 

**Destination channel:** Defaults

### Links

- [PKG-16247]
- dev_url:        https://gitlab.gnome.org/GNOME/at-spi2-core
- conda_forge:    https://github.com/conda-forge/at-spi2-core-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new version number


[PKG-16247]: https://anaconda.atlassian.net/browse/PKG-16247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ